### PR TITLE
Module#define_method returns a symbol instead of a proc in ruby 2.1

### DIFF
--- a/lib/boson/commands/web_core.rb
+++ b/lib/boson/commands/web_core.rb
@@ -24,7 +24,8 @@ module Boson::Commands::WebCore
   def self.def_which_requires(meth, *libs, &block)
     define_method(meth) do |*args|
       libs.each {|e| require e }
-      define_method(meth, block).call(*args)
+      define_method(meth, block)
+      send(meth, *args)
     end
   end
 


### PR DESCRIPTION
Tests pass on MRI 1.9.2 through 2.1 and rbx 2.0 master where I first noticed the issue.
