### PR TITLE
work around ruby 2.2.0 parsing quirk

### DIFF
--- a/lib/boson/repo_index.rb
+++ b/lib/boson/repo_index.rb
@@ -34,11 +34,7 @@ module Boson
     # Reads and initializes index.
     def read
       return if @read
-      @libraries, @commands, @lib_hashes = exists? ?
-        File.open(marshal_file, 'rb') do |f|
-          f.flock(File::LOCK_EX)
-          Marshal.load(f)
-        end : [[], [], {}]
+      @libraries, @commands, @lib_hashes = exists? ? load_index_from_file : [[], [], {}]
       delete_stale_libraries_and_commands
       set_command_namespaces
       @read = true
@@ -129,6 +125,13 @@ module Boson
         h[e] = Digest::MD5.hexdigest(File.read(lib_file)) if File.exists?(lib_file)
         h
       }
+    end
+
+    def load_index_from_file
+      File.open(marshal_file, 'rb') do |f|
+        f.flock(File::LOCK_EX)
+        Marshal.load(f)
+      end
     end
     #:startdoc:
   end


### PR DESCRIPTION
Ruby 2.2.0 has a problem parsing the File.open() do-end stuff in that multi-line ternary assignment in repo_index.rb's read method.

Replacing the do-end with braces works but it's considered bad form if I'm not mistaken so I factored it all out to a separate method.. Tests pass on MRI rubies 1.9.2 - 2.2.0, latest jruby and rbx..